### PR TITLE
Fix/remove update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.apache.commons-beanutils>1.8.3</version.apache.commons-beanutils>
     <version.apache.commons-chain>1.2</version.apache.commons-chain>
     <version.apache.commons-codec>1.4</version.apache.commons-codec>
-    <version.apache.commons-fileupload>1.3</version.apache.commons-fileupload>
+    <version.apache.commons-fileupload>1.3.3</version.apache.commons-fileupload>
     <version.apache.commons-pool>1.6</version.apache.commons-pool>
     <version.apache.commons-io>2.4</version.apache.commons-io>
     <version.apache.commons-collections>3.2.1</version.apache.commons-collections>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.apache.commons-fileupload>1.3.3</version.apache.commons-fileupload>
     <version.apache.commons-pool>1.6</version.apache.commons-pool>
     <version.apache.commons-io>2.4</version.apache.commons-io>
-    <version.apache.commons-collections>3.2.1</version.apache.commons-collections>
+    <version.apache.commons-collections>3.2.2</version.apache.commons-collections>
     <version.apache.commons-lang>2.6</version.apache.commons-lang>
     <version.apache.commons-digester>2.1</version.apache.commons-digester>
     <version.jboss.common>2.2.9.GA</version.jboss.common>

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.picocontainer>1.1</version.picocontainer>
     <version.quartz>2.2.0</version.quartz>
     <version.xpp3>1.1.6</version.xpp3>
-    <version.xstream>1.4.4</version.xstream>
-
     <version.apache.tomcat>6.0.29</version.apache.tomcat>
     <version.apache.xerces>2.9.1</version.apache.xerces>
     <version.apache.poi>3.9</version.apache.poi>
@@ -695,11 +693,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>org.ogce</groupId>
         <artifactId>xpp3</artifactId>
         <version>${version.xpp3}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>${version.xstream}</version>
       </dependency>
       <dependency>
        <groupId>org.jboss.as</groupId>


### PR DESCRIPTION
Bumps commons-fileupload from 1.3 to 1.3.3.
Bump commons-collections from 3.2.1 to 3.2.2
Remove xstream dependency